### PR TITLE
Cleanup web-services client

### DIFF
--- a/qml/mediabox/MediaDetail.qml
+++ b/qml/mediabox/MediaDetail.qml
@@ -259,7 +259,7 @@ Rectangle {
         mediaId = movie.id;
         // FIXME needs to hide/show/animate or whatever nicely - right now it displays old details before new loads
         // 300, 780, 1280
-        backdropImage.source = baseUrl + "w1280/" + movie.backdrop_path
+        backdropImage.source = baseUrl + "w1280" + movie.backdrop_path
         titleLabel.text = movie.title + ' (' + movie.release_date.substring(0,4) + ')'
         overviewLabel.text = movie.overview;
         genresLabel.text = movie.genreNames;

--- a/qml/mediabox/MediaDetail.qml
+++ b/qml/mediabox/MediaDetail.qml
@@ -23,7 +23,16 @@ Rectangle {
     Connections {
         target: moviesListView
         onMediaSelected: {
-            Movies.getMovie(mediaId)
+            Movies.getMovie(
+                mediaId,
+                function(data) {
+                    var movie = data.movie;
+                    movie.genreNames = Movies.genres(movie.genres);
+                    movieDetailView.setMovie(movie);
+                },
+                function(req) {
+                    console.log("Failed to get movie: " + req.status)
+                })
         }
     }
 
@@ -213,7 +222,16 @@ Rectangle {
             text: qsTr("Play")
             iconSource: "xxhdpi/ic_action_play.png"
             onClicked: {
-                Movies.putMedia(0, mediaId)
+                Movies.putMedia(
+                    0,
+                    mediaId,
+                    function() {
+                        main.state = "MEDIA_PLAYER"
+                        console.log("Successfully played media")
+                    },
+                    function() {
+                        console.log("Failed to play media")
+                    })
             }
         }
 
@@ -227,7 +245,16 @@ Rectangle {
             iconSource: "xxhdpi/ic_action_play.png"
             onClicked: {
                 // FIXME play from last position (if there is one)
-                Movies.putMedia(0, mediaId)
+                Movies.putMedia(
+                    0,
+                    mediaId,
+                    function() {
+                        main.state = "MEDIA_PLAYER"
+                        console.log("Successfully played media")
+                    },
+                    function() {
+                        console.log("Failed to play media")
+                    })
             }
         }
 

--- a/qml/mediabox/MediaPlayerView.qml
+++ b/qml/mediabox/MediaPlayerView.qml
@@ -27,7 +27,7 @@ Rectangle {
             text: qsTr("Play")
             iconSource: "xxhdpi/ic_action_play.png"
             onClicked: {
-                Movies.putControl(0, "control", "play")
+                Movies.putControl(0, "control", "play", function() {}, function() {})
             }
         }
 
@@ -41,7 +41,7 @@ Rectangle {
             text: qsTr("Pause")
             iconSource: "xxhdpi/ic_action_pause.png"
             onClicked: {
-                Movies.putControl(0, "control", "pause")
+                Movies.putControl(0, "control", "pause", function() {}, function() {})
             }
         }
 
@@ -55,7 +55,7 @@ Rectangle {
             iconSource: "xxhdpi/ic_action_stop.png"
             text: qsTr("Stop")
             onClicked: {
-                Movies.putControl(0, "control", "stop")
+                Movies.putControl(0, "control", "stop", function() {}, function() {})
                 main.state = "MOVIE"
             }
         }
@@ -70,7 +70,7 @@ Rectangle {
             iconSource: "xxhdpi/ic_action_previous.png"
             text: qsTr("Previous")
             onClicked: {
-                Movies.putControl(0, "chapter", "previous")
+                Movies.putControl(0, "chapter", "previous", function() {}, function() {})
             }
         }
 
@@ -85,7 +85,7 @@ Rectangle {
             iconSource: "xxhdpi/ic_action_next.png"
             text: qsTr("Next")
             onClicked: {
-                Movies.putControl(0, "chapter", "next")
+                Movies.putControl(0, "chapter", "next", function() {}, function() {})
             }
         }
 
@@ -98,7 +98,7 @@ Rectangle {
             anchors.topMargin: 20
             text: qsTr("Slower")
             onClicked: {
-                Movies.putControl(0, "rate", "decrease")
+                Movies.putControl(0, "rate", "decrease", function() {}, function() {})
             }
         }
 
@@ -112,7 +112,7 @@ Rectangle {
             anchors.topMargin: 20
             text: qsTr("Normal")
             onClicked: {
-                Movies.putControl(0, "rate", "reset")
+                Movies.putControl(0, "rate", "reset", function() {}, function() {})
             }
         }
 
@@ -126,7 +126,7 @@ Rectangle {
             anchors.topMargin: 20
             text: qsTr("Faster")
             onClicked: {
-                Movies.putControl(0, "rate", "increase")
+                Movies.putControl(0, "rate", "increase", function() {}, function() {})
             }
         }
 
@@ -139,7 +139,7 @@ Rectangle {
             anchors.topMargin: 20
             text: qsTr("Step")
             onClicked: {
-                Movies.putControl(0, "rate", "step")
+                Movies.putControl(0, "rate", "step", function() {}, function() {})
             }
         }
 
@@ -153,7 +153,7 @@ Rectangle {
             iconSource: "xxhdpi/ic_action_rewind.png"
             text: qsTr("Rewind")
             onClicked: {
-                Movies.putControl(0, "time", "-30000")
+                Movies.putControl(0, "time", "-30000", function() {}, function() {})
             }
         }
 
@@ -168,7 +168,7 @@ Rectangle {
             iconSource: "xxhdpi/ic_action_fast_forward.png"
             text: qsTr("Skip")
             onClicked: {
-                Movies.putControl(0, "time", "+30000")
+                Movies.putControl(0, "time", "+30000", function() {}, function() {})
             }
         }
 
@@ -183,7 +183,7 @@ Rectangle {
             text: qsTr("Mute On")
             checkable: true
             onClicked: {
-                Movies.putControl(0, "volume", "mute")
+                Movies.putControl(0, "volume", "mute", function() {}, function() {})
             }
         }
     }

--- a/qml/mediabox/main.qml
+++ b/qml/mediabox/main.qml
@@ -114,7 +114,15 @@ Rectangle {
                     }
                     onItemHeld: {
                         main.state = 'MEDIA_PLAYER'
-                        Movies.putMedia(0, mediaId)
+                        Movies.putMedia(
+                            0,
+                            mediaId,
+                            function() {
+                                console.log("Successfully played media")
+                            },
+                            function() {
+                                console.log("Failed to play media")
+                            })
                     }
                 }
             }
@@ -126,7 +134,7 @@ Rectangle {
                 Connections {
                     target: main
                     onCurrentMovieChanged: {
-                        movieCastView.setPeople(currentMovie.credits.cast)
+//                        movieCastView.setPeople(currentMovie.credits.cast)
                     }
                 }
             }
@@ -138,7 +146,7 @@ Rectangle {
                 Connections {
                     target: main
                     onCurrentMovieChanged: {
-                        movieCrewView.setPeople(currentMovie.credits.crew)
+//                        movieCrewView.setPeople(currentMovie.credits.crew)
                     }
                 }
             }
@@ -154,7 +162,18 @@ Rectangle {
         }
 
         Component.onCompleted: {
-            Movies.getMovies()
+            Movies.getMovies(
+                function(data) {
+                    for (var i = 0; i < data.entries.length; i++) {
+                        var movie = data.entries[i].movie;
+                        movie.genreNames = Movies.genres(movie.genres);
+                        moviesModel.append(movie);
+                    }
+                    main.state = "MOVIES";
+                },
+                function(req) {
+                    console.log("Failed to get movies: " + req.status)
+                })
         }
     }
 }

--- a/qml/mediabox/movies.js
+++ b/qml/mediabox/movies.js
@@ -4,6 +4,7 @@
 
 /**
  * Get the web-service URL.
+ *
  * @param requestPath
  * @return
  */
@@ -16,21 +17,23 @@ function serviceUrl(requestPath) {
  *
  * @param url request URL
  * @param onSuccess success callback function
+ * @param onError error callback function
  * @return XML HTTP request
  */
-function executeGET(url, onSuccess) {
+function executeGET(url, onSuccess, onError) {
     console.log("[>] executeGET(url=" + url + ")");
     var req = new XMLHttpRequest();
     req.onreadystatechange = function() {
         if (req.readyState === XMLHttpRequest.DONE) {
-            console.log("GET done with status " + req.status);
-            if (req.status === 200) {
+            if (isSuccess(req)) {
                 var json = JSON.parse(req.responseText);
                 onSuccess(json);
             }
+            else {
+                onError(req);
+            }
         }
     }
-    console.log("Execute GET (async)...")
     req.open("GET", url);
     req.send();
     console.log("[<] executeGET()");
@@ -40,23 +43,26 @@ function executeGET(url, onSuccess) {
 /**
  * Execute an HTTP PUT request (asynchronously).
  *
- * @param url
+ * @param url request URL
  * @param type FIXME for now assume text/plain for everything because that's all we need right now
- * @param body
- * @param onSuccess
+ * @param body request body to put
+ * @param onSuccess success callback function
+ * @param onError error callback function
+ * @return XML HTTP request
  */
-function executePUT(url, type, body, onSuccess) {
+function executePUT(url, type, body, onSuccess, onError) {
     console.log("[>] executePUT(url=" + url + ",type=" + type + ",body=" + body + ")");
     var req = new XMLHttpRequest();
     req.onreadystatechange = function() {
         if (req.readyState === XMLHttpRequest.DONE) {
-            console.log("PUT done with status " + req.status);
-            if (req.status === 200 || req.status === 204) { // FIXME!
+            if (isSuccess(req)) {
                 onSuccess();
+            }
+            else {
+                onError(req);
             }
         }
     }
-    console.log("Execute PUT (async)...")
     req.open("PUT", url);
     req.setRequestHeader("Content-Type", "text/plain");
     req.setRequestHeader("Content-Length", body.length);
@@ -67,20 +73,28 @@ function executePUT(url, type, body, onSuccess) {
 }
 
 /**
- * Get the movie media catalog (asynchronously).
+ * Did the request complete successfully?
+ *
+ * @param req XML Http request
+ * @return true if the requested completed successfully; otherwise false
  */
-function getMovies() {
+function isSuccess(req) {
+    return req.status >= 200 && req.status < 300;
+}
+
+/**
+ * Get the movie media catalog (asynchronously).
+ *
+ * @param onSuccess success callback function
+ * @param onError error callback function
+ * @return XML HTTP request
+ */
+function getMovies(onSuccess, onError) {
     console.log("[>] getMovies()")
     var req = executeGET(
         serviceUrl("movies"),
-        function(data) {
-            for (var i = 0; i < data.entries.length; i++) {
-                var movie = data.entries[i].movie;
-                movie.genreNames = genres(movie.genres);
-                moviesModel.append(movie);
-            }
-            main.state = "MOVIES";
-        }
+        onSuccess,
+        onError
     );
     console.log("[<] getMovies()")
     return req;
@@ -90,16 +104,16 @@ function getMovies() {
  * Get details for a particular movie (asynchronously).
  *
  * @param media media identifier
+ * @param onSuccess success callback function
+ * @param onError error callback function
+ * @return XML HTTP request
  */
-function getMovie(media) {
+function getMovie(media, onSuccess, onError) {
     console.log("[>] getMovie(media=" + media + ")");
     var req = executeGET(
         serviceUrl("movies/" + media),
-        function(data) {
-            var movie = data.movie;
-            movie.genreNames = genres(movie.genres);
-            movieDetailView.setMovie(movie);
-        }
+        onSuccess,
+        onError
     );
     console.log("[<] getMovie()");
     return req;
@@ -127,19 +141,25 @@ function genres(genres) {
  *
  * @param mediaPlayer media player identifier
  * @param media identifier of the media to play
+ * @param onSuccess success callback function
+ * @param onError error callback function
+ * @return XML HTTP request
  */
-function putMedia(mediaPlayer, media) {
+function putMedia(mediaPlayer, media, onSuccess, onError) {
     console.log("[>] putMedia(mediaPlayer=" + mediaPlayer + ",media=" + media + ")");
     var req = executePUT(
         serviceUrl("player/" + mediaPlayer + "/media"),
         "text",
         media,
-        function() {
-            console.log("Put media succeeded");
-            main.state = "MEDIA_PLAYER"
-        }
+        onSuccess,
+        onError
+//        function() {
+//            console.log("Put media succeeded");
+//            main.state = "MEDIA_PLAYER"
+//        }
     );
     console.log("[<] putMedia()");
+    return req;
 }
 
 /**
@@ -148,16 +168,19 @@ function putMedia(mediaPlayer, media) {
  * @param mediaPlayer media player identifier
  * @param type type of control to set
  * @param control control value to set
+ * @param onSuccess success callback function
+ * @param onError error callback function
+ * @return XML HTTP request
  */
-function putControl(mediaPlayer, type, control) {
+function putControl(mediaPlayer, type, control, onSuccess, onError) {
     console.log("[>] putControl(mediaPlayer=" + mediaPlayer + ",type=" + type + ",control=" + control + ")");
     var req = executePUT(
         serviceUrl("player/" + mediaPlayer + "/" + type),
         "text",
         control,
-        function() {
-            console.log("Control '" + type + "' to '" + control + "' succeeded");
-        }
+        onSuccess,
+        onError
     );
     console.log("[<] putControl()");
+    return req;
 }

--- a/qml/mediabox/movies.js
+++ b/qml/mediabox/movies.js
@@ -51,7 +51,7 @@ function executePUT(url, type, body, onSuccess) {
     req.onreadystatechange = function() {
         if (req.readyState === XMLHttpRequest.DONE) {
             console.log("PUT done with status " + req.status);
-            if (req.status === 200) {
+            if (req.status === 200 || req.status === 204) { // FIXME!
                 onSuccess();
             }
         }


### PR DESCRIPTION
Clean up the web-service client some more: decouple the web-service client Javascript from the page views, adding success and error callbacks. The page views themselves now implement the page logic, rather than having the page logic in the general web-service client code.

Disable the setting of cast/crew models due to strange bugs reported in the application output log, maybe a race condition, not sure.
